### PR TITLE
CORE-8983: added an additional arity for list-group-privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## [Unreleased]
+### Added
+- An additional arity for `list-group-privileges` that allows privileges to be filtered by privilege name, subject
+  ID, subject type ID, or any combination thereof.
+
 ## [0.1.2]
 ### Added
 - An additional arity for `revoke-group-privileges` that allows privileges to be revoked for several users in a single

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ A client library for the CyVerse groups service.
 
 ;; List group privileges.
 (c/list-group-privileges client "username" "some:group:name")
+(c/list-group-privileges client "username" "some:group:name"
+                         {:privilege         "privilege-name"
+                          :subject-id        "subject-id"
+                          :subject-source-id "subject-source-id"})
 
 ;; Update group privileges for several users.
 (c/update-group-privileges client "username" "some:group:name" {:updates [{:subject_id "subject"

--- a/src/cyverse_groups_client/core.clj
+++ b/src/cyverse_groups_client/core.clj
@@ -51,7 +51,7 @@
   (update-group [_ user name updates]
     "Updates an existing group.")
 
-  (list-group-privileges [_ user name]
+  (list-group-privileges [_ user name] [_ user name params]
     "Lists group privileges.")
 
   (update-group-privileges [_ user name updates] [_ user name updates params]
@@ -222,10 +222,14 @@
                       :content-type :json
                       :as           :json})))
 
-  (list-group-privileges [_ user name]
-    (:body (http/get (build-url base-url "groups" name "privileges")
-                     {:query-params {:user user}
-                      :as           :json})))
+  (list-group-privileges [self user name]
+    (list-group-privileges self user name {}))
+
+  (list-group-privileges [_ user name params]
+    (let [accepted-params [:privilege :subject-id :subject-source-id]]
+      (:body (http/get (build-url base-url "groups" name "privileges")
+                       {:query-params (merge {:user user} (select-keys params accepted-params))
+                        :as           :json}))))
 
   (update-group-privileges [this user name updates]
     (update-group-privileges this user name updates {}))

--- a/test/cyverse_groups_client/core_test.clj
+++ b/test/cyverse_groups_client/core_test.clj
@@ -261,6 +261,13 @@
     (is (= (c/list-group-privileges (create-fake-client) fake-user (:name fake-group))
            fake-group-privileges))))
 
+(deftest test-filtered-group-privilege-listing
+  (let [params {:user fake-user :privilege "foo" :subject-id "bar" :subject-source-id "baz"}]
+    (with-fake-routes {(fake-query-url params "groups" (:name fake-group) "privileges")
+                       {:get (success-fn fake-group-privileges)}}
+      (is (= (c/list-group-privileges (create-fake-client) fake-user (:name fake-group) params)
+             fake-group-privileges)))))
+
 (defn- group-privilege-update-test [expected-updates response-body]
   (fn [request]
     (is (= expected-updates (json/decode (slurp (:body request)) true)))


### PR DESCRIPTION
This new arity allows privileges to be filtered by privilege name, subject ID, subject source ID, or any combination thereof.
